### PR TITLE
Add instruction count and cycle count in run_enclave, also test rdinstret to be a shadow of the actual CSR read

### DIFF
--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -99,6 +99,10 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
   }
 
   /* TODO: verify policy holds / detect any policy violations */
+  if(enclave_detect_policy_violation(eid)){
+    // TODO: response
+    printm("Policy violation detected for enclave with id: %d", eid);
+  }
 
   /* Todo: printm output of policy structs to verify */
 

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -130,8 +130,7 @@ static inline void context_switch_to_host(uintptr_t* encl_regs,
   /* calculate policy counter */
   enclave_policies[eid].instr_run_tot = enclave_policies[eid].instr_run_tot + ((uint64_t)read_csr(minstret) - enclave_policies[eid].instr_count);
   enclave_policies[eid].cycles_run_tot = enclave_policies[eid].cycles_run_tot + ((uint64_t)read_csr(mcycle) - enclave_policies[eid].cycle_count);
-  printm("EID: %5d, %10s %10x, %10s %10x\n", eid, "instr_run_total:", enclave_policies[eid].instr_run_tot, "cycles_run_total:", enclave_policies[eid].cycles_run_tot);
-
+  printm("EID: %5d, %10s %15x, %10s %15x\n", (int)eid, "instr_run_total:", enclave_policies[eid].instr_run_tot, "cycles_run_total:", enclave_policies[eid].cycles_run_tot);
 
   // set PMP
   int memid;

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -437,9 +437,9 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
   pa_params.user_base = create_args.user_paddr;
   pa_params.free_base = create_args.free_paddr;
 
-  /* set policy */
-  uint64_t instr_per_epoch = create_args.instr_per_epoch;
-  uint64_t cycles_per_epoch = create_args.cycles_per_epoch;
+  /* set policy params*/
+  uint64_t want_instr_per_epoch = create_args.instr_per_epoch;
+  uint64_t want_cycles_per_epoch = create_args.cycles_per_epoch;
 
   // allocate eid
   ret = ENCLAVE_NO_FREE_RESOURCE;
@@ -480,9 +480,15 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
    * if so, verify that the policy can be fulfilled
    * TODO: verify all policies first
    */
-  if(enclave_validate_policy(&instr_per_epoch, &cycles_per_epoch)){
-    enclaves[eid].policy.want_instr_per_epoch = instr_per_epoch;
-    enclaves[eid].policy.want_cycles_per_epoch = cycles_per_epoch;
+  if(enclave_validate_policy(&want_instr_per_epoch, &want_cycles_per_epoch)){
+    enclaves[eid].policy.want_instr_per_epoch = want_instr_per_epoch;
+    enclaves[eid].policy.want_cycles_per_epoch = want_cycles_per_epoch;
+
+    /* set counter */
+    enclave_policies[eid].instr_count = 0;
+    enclave_policies[eid].cycle_count = 0;
+    enclave_policies[eid].instr_run_tot = 0;
+    enclave_policies[eid].cycles_run_tot = 0;
   }
 
   /* Init enclave state (regs etc) */

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -17,9 +17,6 @@
 struct enclave enclaves[ENCL_MAX];
 #define ENCLAVE_EXISTS(eid) (eid >= 0 && eid < ENCL_MAX && enclaves[eid].state >= 0)
 
-/* enclave_policy holds information about the instructions/cycles run by each enclave */
-struct enclave_policy_counter enclave_policies[ENCL_MAX];
-
 static spinlock_t encl_lock = SPINLOCK_INIT;
 
 extern void save_host_regs(void);
@@ -126,11 +123,6 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
 static inline void context_switch_to_host(uintptr_t* encl_regs,
     enclave_id eid,
     int return_on_resume){
-
-  /* calculate policy counter */
-  enclave_policies[eid].instr_run_tot = enclave_policies[eid].instr_run_tot + ((uint64_t)read_csr(minstret) - enclave_policies[eid].instr_count);
-  enclave_policies[eid].cycles_run_tot = enclave_policies[eid].cycles_run_tot + ((uint64_t)read_csr(mcycle) - enclave_policies[eid].cycle_count);
-  printm("EID: %5d, %10s %15x, %10s %15x\n", (int)eid, "instr_run_total:", enclave_policies[eid].instr_run_tot, "cycles_run_total:", enclave_policies[eid].cycles_run_tot);
 
   // set PMP
   int memid;

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -551,6 +551,30 @@ enclave_ret_code run_enclave(uintptr_t* host_regs, enclave_id eid)
 {
   int runable;
 
+  // print the CSR minstret three times in a row
+  // note that for better accuracy qemu should be
+  // invoked with -icount auto
+  // minstret: retired instructions counter
+  intptr_t instr_count = read_csr(minstret);
+  printm("\nInstruction count:%x\n", instr_count);
+  intptr_t instr_count2 = read_csr(minstret);
+  printm("Instructions count:%x\n", instr_count2);
+  intptr_t instr_count3 = read_csr(minstret);
+  printm("Instructions count:%x\n", instr_count3);
+
+  // mcycle: cycle counter
+  intptr_t cycle_count = read_csr(mcycle);
+  printm("\nCycle count:%x\n", cycle_count);
+  intptr_t cycle_count2 = read_csr(mcycle);
+  printm("Cycle count:%x\n", cycle_count2);
+  intptr_t cycle_count3 = read_csr(mcycle);
+  printm("Cycle count:%x\n", cycle_count3);
+ 
+  // see if rdinstret actualy shadows the CSR minstret
+  printm("\npseudoinstruction instr count:%x\n", rdinstret());
+  printm("pseudoinstruction instr count:%x\n", rdinstret());
+  printm("pseudoinstruction instr count:%x\n", rdinstret());
+
   spinlock_lock(&encl_lock);
   runable = (ENCLAVE_EXISTS(eid)
             && enclaves[eid].state == FRESH);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -109,6 +109,12 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
     enclaves[eid].policy_counter.instr_count = (uint64_t)read_csr(minstret) - enclaves[eid].policy_counter.instr_count;
   }
 
+/* print output to see the current instruction count
+ * note that the instruction count is either the first time read of the minstret CSR
+ * or it is the difference of instructions retired between the start/resuming of the enclave
+ */
+  printm("EID: %5x, %10s %10x \n", eid, "instr_count:", enclaves[eid].policy_counter.instr_count);
+
   /* TODO: verify policy holds / detect any policy violations */
   if(enclave_detect_policy_violation(eid)){
     // TODO: response
@@ -594,30 +600,6 @@ enclave_ret_code destroy_enclave(enclave_id eid)
 enclave_ret_code run_enclave(uintptr_t* host_regs, enclave_id eid)
 {
   int runable;
-
-  // print the CSR minstret three times in a row
-  // note that for better accuracy qemu should be
-  // invoked with -icount auto
-  // minstret: retired instructions counter
-  intptr_t instr_count = read_csr(minstret);
-  printm("\nInstruction count:%x\n", instr_count);
-  intptr_t instr_count2 = read_csr(minstret);
-  printm("Instructions count:%x\n", instr_count2);
-  intptr_t instr_count3 = read_csr(minstret);
-  printm("Instructions count:%x\n", instr_count3);
-
-  // mcycle: cycle counter
-  intptr_t cycle_count = read_csr(mcycle);
-  printm("\nCycle count:%x\n", cycle_count);
-  intptr_t cycle_count2 = read_csr(mcycle);
-  printm("Cycle count:%x\n", cycle_count2);
-  intptr_t cycle_count3 = read_csr(mcycle);
-  printm("Cycle count:%x\n", cycle_count3);
- 
-  // see if rdinstret actually shadows the CSR minstret
-  printm("\npseudoinstruction instr count:%x\n", rdinstret());
-  printm("pseudoinstruction instr count:%x\n", rdinstret());
-  printm("pseudoinstruction instr count:%x\n", rdinstret());
 
   spinlock_lock(&encl_lock);
   runable = (ENCLAVE_EXISTS(eid)

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -60,6 +60,28 @@ struct enclave_region
   enum enclave_region_type type;
 };
 
+/* Enclave policy 
+ * Each enclave can register a policy of
+ * how many instructions/cycles it wants
+ * to run in an epoch
+ */
+struct enclave_policy
+{
+  uint64_t instr_per_epoch;
+  uint64_t cycles_per_epoch;
+};
+
+/* Enclave policy counter
+ * Tracking the instruction and
+ * cycle count that an enclave was able to
+ * run during an epoch
+ */
+struct enclave_policy_counter
+{
+  uint64_t instr_count;
+  uint64_t cycle_count;
+};
+
 /* enclave metadata */
 struct enclave
 {
@@ -117,28 +139,6 @@ struct sealing_key
 {
   uint8_t key[SEALING_KEY_SIZE];
   uint8_t signature[SIGNATURE_SIZE];
-};
-
-/* Enclave policy 
- * Each enclave can register a policy of
- * how many instructions/cycles it wants
- * to run in an epoch
- */
-struct enclave_policy
-{
-  unsigned int instr_per_epoch;
-  unsigned int cycles_per_epoch;
-};
-
-/* Enclave policy counter
- * Tracking the instruction and
- * cycle count that an enclave was able to
- * run during an epoch
- */
-struct enclave_policy_counter
-{
-  unsigned int instr_count;
-  unsigned int cycle_count;
 };
 
 

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -67,8 +67,8 @@ struct enclave_region
  */
 struct enclave_policy
 {
-  uint64_t instr_per_epoch;
-  uint64_t cycles_per_epoch;
+  uint64_t want_instr_per_epoch;
+  uint64_t want_cycles_per_epoch;
 };
 
 /* Enclave policy counter
@@ -78,8 +78,10 @@ struct enclave_policy
  */
 struct enclave_policy_counter
 {
-  uint64_t instr_count;
+  uint64_t instr_count; // stores the most recent CSR value of when the enclave was run/resumed
   uint64_t cycle_count;
+  uint64_t instr_run_tot; // the sum of instructions that were run
+  uint64_t cycles_run_tot;
 };
 
 /* enclave metadata */
@@ -109,7 +111,6 @@ struct enclave
 
   /* the enclaves policy */
   struct enclave_policy policy;
-  struct enclave_policy_counter policy_counter;
 };
 
 /* attestation reports */

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -19,6 +19,7 @@
 // Special target platform header, set by configure script
 #include TARGET_PLATFORM_HEADER
 
+#define ENCL_MAX 16
 #define ATTEST_DATA_MAXLEN  1024
 #define ENCLAVE_REGIONS_MAX 8
 /* TODO: does not support multithreaded enclave yet */
@@ -74,7 +75,7 @@ struct enclave_policy
 /* Enclave policy counter
  * Tracking the instruction and
  * cycles that an enclave was able to
- * run during an epoch
+ * run during an epochenclave_policies
  */
 struct enclave_policy_counter
 {
@@ -142,6 +143,8 @@ struct sealing_key
   uint8_t signature[SIGNATURE_SIZE];
 };
 
+/* enclave_policy holds information about the instructions/cycles run by each enclave */
+struct enclave_policy_counter enclave_policies[ENCL_MAX];
 
 /*** SBI functions & external functions ***/
 // callables from the host

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -73,7 +73,7 @@ struct enclave_policy
 
 /* Enclave policy counter
  * Tracking the instruction and
- * cycle count that an enclave was able to
+ * cycles that an enclave was able to
  * run during an epoch
  */
 struct enclave_policy_counter

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -84,6 +84,10 @@ struct enclave
   struct thread_state threads[MAX_ENCL_THREADS];
 
   struct platform_enclave_data ped;
+
+  /* the enclaves policy */
+  struct enclave_policy policy;
+  struct enclave_policy_counter policy_counter;
 };
 
 /* attestation reports */
@@ -114,6 +118,29 @@ struct sealing_key
   uint8_t key[SEALING_KEY_SIZE];
   uint8_t signature[SIGNATURE_SIZE];
 };
+
+/* Enclave policy 
+ * Each enclave can register a policy of
+ * how many instructions/cycles it wants
+ * to run in an epoch
+ */
+struct enclave_policy
+{
+  unsigned int instr_per_epoch;
+  unsigned int cycles_per_epoch;
+};
+
+/* Enclave policy counter
+ * Tracking the instruction and
+ * cycle count that an enclave was able to
+ * run during an epoch
+ */
+struct enclave_policy_counter
+{
+  unsigned int instr_count;
+  unsigned int cycle_count;
+};
+
 
 /*** SBI functions & external functions ***/
 // callables from the host

--- a/sm/sm-sbi.c
+++ b/sm/sm-sbi.c
@@ -78,7 +78,13 @@ uintptr_t mcall_sm_exit_enclave(uintptr_t* encl_regs, unsigned long retval)
     return ENCLAVE_SBI_PROHIBITED;
   }
 
-  ret = exit_enclave(encl_regs, (unsigned long) retval, cpu_get_enclave_id());
+  /* calculate policy counter */
+  int eid = cpu_get_enclave_id();
+  enclave_policies[eid].instr_run_tot = enclave_policies[eid].instr_run_tot + ((uint64_t)read_csr(minstret) - enclave_policies[eid].instr_count);
+  enclave_policies[eid].cycles_run_tot = enclave_policies[eid].cycles_run_tot + ((uint64_t)read_csr(mcycle) - enclave_policies[eid].cycle_count);
+  printm("EID: %5d, %10s %ld, %10s %ld\n", eid, "instr_run_total:", enclave_policies[eid].instr_run_tot, "cycles_run_total:", enclave_policies[eid].cycles_run_tot);
+
+  ret = exit_enclave(encl_regs, (unsigned long) retval, eid);
   return ret;
 }
 
@@ -90,7 +96,13 @@ uintptr_t mcall_sm_stop_enclave(uintptr_t* encl_regs, unsigned long request)
     return ENCLAVE_SBI_PROHIBITED;
   }
 
-  ret = stop_enclave(encl_regs, (uint64_t)request, cpu_get_enclave_id());
+  /* calculate policy counter */
+  int eid = cpu_get_enclave_id();
+  enclave_policies[eid].instr_run_tot = enclave_policies[eid].instr_run_tot + ((uint64_t)read_csr(minstret) - enclave_policies[eid].instr_count);
+  enclave_policies[eid].cycles_run_tot = enclave_policies[eid].cycles_run_tot + ((uint64_t)read_csr(mcycle) - enclave_policies[eid].cycle_count);
+  printm("EID: %5d, %10s %ld, %10s %ld\n", eid, "instr_run_total:", enclave_policies[eid].instr_run_tot, "cycles_run_total:", enclave_policies[eid].cycles_run_tot);
+
+  ret = stop_enclave(encl_regs, (uint64_t)request, eid);
   return ret;
 }
 

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -103,8 +103,8 @@ struct keystone_sbi_create
   unsigned int* eid_pptr;
 
   /* define optional policy */
-  unsigned int instr_per_epoch;
-  unsigned int cycles_per_epoch;
+  uint64_t instr_per_epoch;
+  uint64_t cycles_per_epoch;
 };
 
 /* Define dynamic structure to keep 

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -101,7 +101,22 @@ struct keystone_sbi_create
 
   struct runtime_va_params_t params;
   unsigned int* eid_pptr;
+
+  /* define optional policy */
+  unsigned int instr_per_epoch;
+  unsigned int cycles_per_epoch;
 };
+
+/* Define dynamic structure to keep 
+ * track of the enclaves policies
+ */
+/*struct enclave_policies
+{
+  enclave_id eid;
+  struct enclave_policy;
+  struct enclave_policy_counter;
+  struct enclave_policies * next;
+};*/
 
 int osm_pmp_set(uint8_t perm);
 #endif


### PR DESCRIPTION
 - added the output of the following CSRs captured three times in a row
     - CSR mcycle: the cycle count
     - CSR minstret: the retired instruction count

 - note that the output is only visible in qemu, not in the std out when running the standart test enclaves from the `keystone/build` folder